### PR TITLE
Fixed typo in HW8_Ex2.hs

### DIFF
--- a/exercises/HW08/HW8_Ex2.hs
+++ b/exercises/HW08/HW8_Ex2.hs
@@ -42,6 +42,6 @@ putStrLn'g xs = putStr' xs >> putStr' "\n"
 
 {-
 -- answer h
-putStrLn'h [] = putChar '\n'
+putStrLn'h [] = putChar "\n"
 putStrLn'h xs = putStr' xs >> putChar '\n'
 -}


### PR DESCRIPTION
This fixes a typo which has an impact on the correct answers for the exercise.
