### PR TITLE
Fixed syntax of answer g in HW9_Ex1.hs

### DIFF
--- a/exercises/HW09/HW9_Ex1.hs
+++ b/exercises/HW09/HW9_Ex1.hs
@@ -47,6 +47,7 @@ integerToNatg = head . m
     where {
         ; m 0 = [0]
         ; m (n + 1) = [sum [x | x <- (1 : m n)]]
+        }
 -}
 
 {-


### PR DESCRIPTION
Added the missing closing brace in answer g in HW9_Ex1.hs
